### PR TITLE
WIP: Add cblas_xerbla_set to exchange the error handler

### DIFF
--- a/CBLAS/include/cblas.h
+++ b/CBLAS/include/cblas.h
@@ -1,7 +1,7 @@
 #ifndef CBLAS_H
 #define CBLAS_H
 #include <stddef.h>
-
+#include <stdarg.h>
 
 #ifdef __cplusplus
 extern "C" {            /* Assume C declarations for C++ */
@@ -579,8 +579,34 @@ void cblas_zher2k(CBLAS_LAYOUT layout, CBLAS_UPLO Uplo,
                   const void *alpha, const void *A, const int lda,
                   const void *B, const int ldb, const double beta,
                   void *C, const int ldc);
+/*
+ * Error Handling
+ */
+
+/*
+ * Type definition for the user supplied error handler. The error
+ * handler gets an additional first argument, which may contain
+ * auxilliary data provided by the user. The return value decides
+ * whether the default cblas_xerbla will continue (1) or not (0).
+ * In this way the standard handler can be replaced or extended.
+ */
+typedef int (*cblas_xerbla_function_t)(void *, int, const char*, const char*, va_list);
+
+/*
+ * Set a new error handler called by cblas_xerbla. A previously set error handler
+ * is returned by the function such that it can be restored afterwards.
+ */
+cblas_xerbla_function_t cblas_xerbla_set(cblas_xerbla_function_t new_handler);
+
+/*
+ * Set the auxilliary data for the error handler. The previously set value is
+ * returned by the function such that it can be restored afterwards.
+ */
+void * cblas_xerbla_set_aux(void *aux);
+
 
 void cblas_xerbla(int p, const char *rout, const char *form, ...);
+
 
 #ifdef __cplusplus
 }

--- a/CBLAS/include/cblas_test.h
+++ b/CBLAS/include/cblas_test.h
@@ -21,6 +21,8 @@
 typedef struct { float real; float imag; } CBLAS_TEST_COMPLEX;
 typedef struct { double real; double imag; } CBLAS_TEST_ZOMPLEX;
 
+extern void cblas_xerbla_test_init();
+
 #define F77_xerbla 		F77_GLOBAL(xerbla,XERBLA)
 /*
  * Level 1 BLAS

--- a/CBLAS/src/cblas_xerbla.c
+++ b/CBLAS/src/cblas_xerbla.c
@@ -1,3 +1,8 @@
+/*
+ * CBLAS Error handling.
+ * Rewrite by Martin Koehler <koehlerm(AT)mpi-magdeburg.mpg.de>
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -5,13 +10,49 @@
 #include "cblas.h"
 #include "cblas_f77.h"
 
+// typedef int (*cblas_xerbla_function_t)(void *, int, const char*, const char*, va_list);
+// cblas_xerbla_function_t cblas_xerbla_set(cblas_xerbla_function_t new_handler);
+// void * cblas_xerbla_set_aux(void *aux);
+
+/* Initialize the default  */
+static void *errhandler_aux = NULL;
+static cblas_xerbla_function_t errorhandler = NULL;
+
+cblas_xerbla_function_t cblas_xerbla_set(cblas_xerbla_function_t new_handler)
+{
+    cblas_xerbla_function_t old_handler = errorhandler;
+    errorhandler = new_handler;
+    return old_handler;
+}
+
+void *cblas_xerbla_set_aux(void *aux)
+{
+    void *oldaux = errhandler_aux;
+    errhandler_aux = aux;
+    return oldaux;
+}
+
+
 void cblas_xerbla(int info, const char *rout, const char *form, ...)
 {
    extern int RowMajorStrg;
    char empty[1] = "";
    va_list argptr;
+   int ret_handler = 1;
 
    va_start(argptr, form);
+
+   if ( errorhandler != NULL )
+   {
+        va_list argptr2;
+        va_copy(argptr, argptr2);
+        ret_handler = errorhandler(errhandler_aux, info, rout, form, argptr2);
+        va_end(argptr2);
+   }
+
+
+   if ( ret_handler == 0 )
+       return;
 
    if (RowMajorStrg)
    {

--- a/CBLAS/testing/c_c2chke.c
+++ b/CBLAS/testing/c_c2chke.c
@@ -36,9 +36,10 @@ void F77_c2chke(char *rout) {
    extern int RowMajorStrg;
    extern char *cblas_rout;
 
+   cblas_xerbla_test_init();
+
    if (link_xerbla) /* call these first to link */
    {
-      cblas_xerbla(cblas_info,cblas_rout,"");
       F77_xerbla(cblas_rout,&cblas_info);
    }
 

--- a/CBLAS/testing/c_c3chke.c
+++ b/CBLAS/testing/c_c3chke.c
@@ -39,9 +39,10 @@ void  F77_c3chke(char *  rout) {
    cblas_ok = TRUE ;
    cblas_lerr = PASSED ;
 
+   cblas_xerbla_test_init();
+
    if (link_xerbla) /* call these first to link */
    {
-      cblas_xerbla(cblas_info,cblas_rout,"");
       F77_xerbla(cblas_rout,&cblas_info);
    }
 

--- a/CBLAS/testing/c_d2chke.c
+++ b/CBLAS/testing/c_d2chke.c
@@ -34,9 +34,10 @@ void F77_d2chke(char *rout) {
    extern int RowMajorStrg;
    extern char *cblas_rout;
 
+   cblas_xerbla_test_init();
+
    if (link_xerbla) /* call these first to link */
    {
-      cblas_xerbla(cblas_info,cblas_rout,"");
       F77_xerbla(cblas_rout,&cblas_info);
    }
 

--- a/CBLAS/testing/c_d3chke.c
+++ b/CBLAS/testing/c_d3chke.c
@@ -34,9 +34,10 @@ void F77_d3chke(char *rout) {
    extern int RowMajorStrg;
    extern char *cblas_rout;
 
+   cblas_xerbla_test_init();
+
    if (link_xerbla) /* call these first to link */
    {
-      cblas_xerbla(cblas_info,cblas_rout,"");
       F77_xerbla(cblas_rout,&cblas_info);
    }
 

--- a/CBLAS/testing/c_s2chke.c
+++ b/CBLAS/testing/c_s2chke.c
@@ -34,9 +34,10 @@ void F77_s2chke(char *rout) {
    extern int RowMajorStrg;
    extern char *cblas_rout;
 
+   cblas_xerbla_test_init();
+
    if (link_xerbla) /* call these first to link */
    {
-      cblas_xerbla(cblas_info,cblas_rout,"");
       F77_xerbla(cblas_rout,&cblas_info);
    }
 

--- a/CBLAS/testing/c_s3chke.c
+++ b/CBLAS/testing/c_s3chke.c
@@ -34,9 +34,10 @@ void F77_s3chke(char *rout) {
    extern int RowMajorStrg;
    extern char *cblas_rout;
 
+   cblas_xerbla_test_init();
+
    if (link_xerbla) /* call these first to link */
    {
-      cblas_xerbla(cblas_info,cblas_rout,"");
       F77_xerbla(cblas_rout,&cblas_info);
    }
 

--- a/CBLAS/testing/c_xerbla.c
+++ b/CBLAS/testing/c_xerbla.c
@@ -5,7 +5,15 @@
 #include "cblas.h"
 #include "cblas_test.h"
 
-void cblas_xerbla(int info, const char *rout, const char *form, ...)
+int cblas_xerbla_handler(void * aux, int info, const char *rout, const char *form, va_list ap);
+
+void cblas_xerbla_test_init()
+{
+    cblas_xerbla_set(cblas_xerbla_handler);
+    cblas_xerbla_set_aux(NULL);
+}
+
+int cblas_xerbla_handler(void * aux, int info, const char *rout, const char *form, va_list ap)
 {
    extern int cblas_lerr, cblas_info, cblas_ok;
    extern int link_xerbla;
@@ -17,7 +25,6 @@ void cblas_xerbla(int info, const char *rout, const char *form, ...)
     * This is done to fool the linker into loading these subroutines first
     * instead of ones in the CBLAS or the legacy BLAS library.
     */
-   if (link_xerbla) return;
 
    if (cblas_rout != NULL && strcmp(cblas_rout, rout) != 0){
       printf("***** XERBLA WAS CALLED WITH SRNAME = <%s> INSTEAD OF <%s> *******\n", rout, cblas_rout);
@@ -82,6 +89,8 @@ void cblas_xerbla(int info, const char *rout, const char *form, ...)
       cblas_lerr = PASSED;
       cblas_ok = FALSE;
    } else cblas_lerr = FAILED;
+
+   return 0;
 }
 
 #ifdef F77_Char

--- a/CBLAS/testing/c_z2chke.c
+++ b/CBLAS/testing/c_z2chke.c
@@ -36,9 +36,10 @@ void F77_z2chke(char *rout) {
    extern int RowMajorStrg;
    extern char *cblas_rout;
 
+   cblas_xerbla_test_init();
+
    if (link_xerbla) /* call these first to link */
    {
-      cblas_xerbla(cblas_info,cblas_rout,"");
       F77_xerbla(cblas_rout,&cblas_info);
    }
 

--- a/CBLAS/testing/c_z3chke.c
+++ b/CBLAS/testing/c_z3chke.c
@@ -39,9 +39,10 @@ void  F77_z3chke(char *  rout) {
    cblas_ok = TRUE ;
    cblas_lerr = PASSED ;
 
+   cblas_xerbla_test_init();
+
    if (link_xerbla) /* call these first to link */
    {
-      cblas_xerbla(cblas_info,cblas_rout,"");
       F77_xerbla(cblas_rout,&cblas_info);
    }
 


### PR DESCRIPTION
The error handling in BLAS, CBLAS, LAPACK, ... still relies on ideas based on static linking of a program and replacing cblas_xerbla, xerbla, ... during the linking process. The usage of dynamic libraries and, sometimes, complicated linking procedures, make the old way more and more complicated. For this reason, the error handling needs to be reworked to be more flexible.

I propose to add a type definition:
```
/*
 * Type definition for the user supplied error handler. The error
 * handler gets an additional first argument, which may contain
 * auxilliary data provided by the user. The return value decides
 * whether the default cblas_xerbla will continue (1) or not (0).
 * In this way the standard handler can be replaced or extended.
 */
typedef int (*cblas_xerbla_function_t)(void *, int, const char*, const char*, va_list);

```
and two new functions 
```
/*
 * Set a new error handler called by cblas_xerbla. A previously set error handler
 * is returned by the function such that it can be restored afterwards.
 */
cblas_xerbla_function_t cblas_xerbla_set(cblas_xerbla_function_t new_handler);

/*
 * Set the auxilliary data for the error handler. The previously set value is
 * returned by the function such that it can be restored afterwards.
 */
void * cblas_xerbla_set_aux(void *aux);


```
to CBLAS. Once the user called `cblas_xerbla_set` its own error handler gets activated. If this handler returns 0, the error handling is finished, if it returns 1, the original `cblas_xerbla` handler is executed afterwards. If the error handler needs axillary data from the user, like application states or information to display a GUI warning, the `cblas_xerbla_set_aux` function is used to pass an opaque object to the error handling function.  By setting the error handler to `NULL` the default `cblas_xerbla` routine is restored. 

In this way the error handler can be changed at runtime. 

I changed the reference implementation and corresponding tests such that the above mentioned system works.  